### PR TITLE
Use jsonpointer to resolve refs

### DIFF
--- a/index.js
+++ b/index.js
@@ -475,7 +475,7 @@ docson.doc = function(element, schema, ref, baseUrl) {
                                 }
                             }
                             if(content) {
-                                refs[item] = content;
+                                refs[item] = jsonpointer.get(content, segments[1]);
                                 renderBox();
                                 resolveRefsReentrant(content);
                             }
@@ -494,7 +494,7 @@ docson.doc = function(element, schema, ref, baseUrl) {
                                 }
                             }
                             if(content) {
-                                refs[item] = content;
+                                refs[item] = jsonpointer.get(content, segments[1]);
                                 renderBox();
                                 resolveRefsReentrant(content);
                             }


### PR DESCRIPTION
When fetching refs with paths such as other.json#/some/path, use jsonpointer to resolve #/some/path and store just that part of the object in the refs map.

HT lbovet/docson/pull/41
